### PR TITLE
Allow STS token to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Full list of options in `config.json`:
 | dbname                              | String  | Yes        | Redshift Database name                                        |
 | aws_access_key_id                   | String  | No         | S3 Access Key Id. Used for S3 and Redshfit copy operations. If not provided, credentials will be collected from the environment                                              |
 | aws_secret_access_key               | String  | No         | S3 Secret Access Key. Used for S3 and Redshfit copy operations. If not provided, credentials will be collected from the environment                                          |
+| aws_session_token                   | String  | No         | S3 AWS STS token for temporary credentials                |
 | aws_redshift_copy_role_arn          | String  | No         | AWS Role ARN to be used for the Redshift COPY operation. Used instead of the given AWS keys for the COPY operation if provided - the keys are still used for other S3 operations |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can upload files into specific directories in the S3 bucket. |
@@ -96,7 +97,9 @@ Full list of options in `config.json`:
 ### To run tests:
 
 1. Install python dependencies in a virtual env:
-```
+
+
+```bash
   python3 -m venv venv
   . venv/bin/activate
   pip install --upgrade pip
@@ -104,13 +107,16 @@ Full list of options in `config.json`:
   pip install pytest coverage
 ```
 
-3. To run unit tests:
-```
+1. To run unit tests:
+
+
+```bash
   coverage run -m pytest --disable-pytest-warnings tests/unit && coverage report
 ```
 
 1. To run integration tests define environment variables first:
-```
+
+```bash
   export TARGET_REDSHIFT_HOST=<redshift-host>
   export TARGET_REDSHIFT_PORT=<redshift-port>
   export TARGET_REDSHIFT_USER=<redshift-user>
@@ -128,7 +134,9 @@ Full list of options in `config.json`:
 ### To run pylint:
 
 1. Install python dependencies and run python linter
-```
+
+
+```bash
   python3 -m venv venv
   . venv/bin/activate
   pip install --upgrade pip

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -215,7 +215,8 @@ class DbSync:
         # Init S3 client
         aws_session = boto3.session.Session(
             aws_access_key_id=self.connection_config.get('aws_access_key_id'),
-            aws_secret_access_key=self.connection_config.get('aws_secret_access_key')
+            aws_secret_access_key=self.connection_config.get('aws_secret_access_key'),
+            aws_session_token=self.connection_config.get('aws_session_token'),
         )
         credentials = aws_session.get_credentials().get_frozen_credentials()
 
@@ -384,9 +385,11 @@ class DbSync:
                 """.format(aws_role_arn=self.connection_config['aws_redshift_copy_role_arn']) if self.connection_config.get("aws_redshift_copy_role_arn") else """
                     ACCESS_KEY_ID '{aws_access_key_id}'
                     SECRET_ACCESS_KEY '{aws_secret_access_key}'
+                    {aws_session_token}
                 """.format(
                     aws_access_key_id=self.connection_config['aws_access_key_id'],
                     aws_secret_access_key=self.connection_config['aws_secret_access_key'],
+                    aws_session_token="SESSION_TOKEN '{}'".format(self.connection_config['aws_session_token']) if self.connection_config.get('aws_session_token') else '',
                 )
 
                 # Step 3: Generate copy options - Override defaults from config.json if defined


### PR DESCRIPTION
This allows a workaround for temporary credential usage, which gives the possibility of using IAM roles via STS.

The example use case here is using Apache Airflow: I wish to use the built in credentials providers which airflow uses - to do this I'm using IAM roles which are assumed by boto3 automatically, and then taking the access key/secret key/sts token and providing them to libraries which need them.

It'd be equally useful to allow an AWS profile or role to be used in future, specifically to separate the role used by Redshift COPY and the S3 credentials to do the multipart upload.

Tested against our redshift environment.

See equivalent PR for the other open source redshift target https://github.com/datamill-co/target-redshift/pull/31