### PR TITLE
Allow boto3 to discover credentials, add `aws_redshift_copy_role_arn` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ Full list of options in `config.json`:
 | user                                | String  | Yes        | Redshift User                                                 |
 | password                            | String  | Yes        | Redshift Password                                             |
 | dbname                              | String  | Yes        | Redshift Database name                                        |
-| aws_access_key_id                   | String  | Yes        | S3 Access Key Id                                              |
-| aws_secret_access_key               | String  | Yes        | S3 Secret Access Key                                          |
+| aws_access_key_id                   | String  | No         | S3 Access Key Id. Used for S3 and Redshfit copy operations. If not provided, credentials will be collected from the environment                                              |
+| aws_secret_access_key               | String  | No         | S3 Secret Access Key. Used for S3 and Redshfit copy operations. If not provided, credentials will be collected from the environment                                          |
+| aws_redshift_copy_role_arn          | String  | No         | AWS Role ARN to be used for the Redshift COPY operation. Used instead of the given AWS keys for the COPY operation if provided - the keys are still used for other S3 operations |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can upload files into specific directories in the S3 bucket. |
 | copy_options                        | String  |            | (Default: `EMPTYASNULL BLANKSASNULL TRIMBLANKS TRUNCATECOLUMNS TIMEFORMAT 'auto' COMPUPDATE OFF STATUPDATE OFF`). Parameters to use in the COPY command when loading data to Redshift. Some basic file formatting parameters are fixed values and not recommended overriding them by custom values. They are like: `CSV GZIP DELIMITER ',' REMOVEQUOTES ESCAPE` |

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -220,7 +220,7 @@ class DbSync:
         credentials = aws_session.get_credentials().get_frozen_credentials()
 
         self.s3 = aws_session.client('s3')
-        
+
         # Explicitly set credentials to those fetched from Boto so we can re-use them in COPY SQL if necessary
         self.connection_config['aws_access_key_id'] = credentials.access_key
         self.connection_config['aws_secret_access_key'] = credentials.secret_key
@@ -381,7 +381,7 @@ class DbSync:
                 # Step 2: Generate copy credentials - prefer role if provided, otherwise use access and secret keys
                 copy_credentials = """
                     iam_role '{aws_role_arn}'
-                """.format(aws_role_arn=self.connection_config['aws_redshift_copy_role_arn']) if "aws_redshift_copy_role_arn" in self.connection_config else """
+                """.format(aws_role_arn=self.connection_config['aws_redshift_copy_role_arn']) if self.connection_config.get("aws_redshift_copy_role_arn") else """
                     ACCESS_KEY_ID '{aws_access_key_id}'
                     SECRET_ACCESS_KEY '{aws_secret_access_key}'
                 """.format(

--- a/tests/integration/test_target_redshift.py
+++ b/tests/integration/test_target_redshift.py
@@ -14,29 +14,28 @@ except ImportError:
     import utils as test_utils
 
 
-METADATA_COLUMNS = [
-    '_sdc_extracted_at',
-    '_sdc_batched_at',
-    '_sdc_deleted_at'
-]
+METADATA_COLUMNS = ["_sdc_extracted_at", "_sdc_batched_at", "_sdc_deleted_at"]
 
 
 class TestTargetRedshift(object):
     """
     UnIntegrationit Tests for PipelineWise Target Redshift
     """
+
     def setup_method(self):
         self.config = test_utils.get_test_config()
         redshift = DbSync(self.config)
 
         # Drop target schema
-        if self.config['default_target_schema']:
-            redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
-
+        if self.config["default_target_schema"]:
+            redshift.query(
+                "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                    self.config["default_target_schema"]
+                )
+            )
 
     def teardown_method(self):
         pass
-
 
     def remove_metadata_columns_from_rows(self, rows):
         """Removes metadata columns from a list of rows"""
@@ -53,13 +52,11 @@ class TestTargetRedshift(object):
 
         return d_rows
 
-
     def assert_metadata_columns_exist(self, rows):
         """This is a helper assertion that checks if every row in a list has metadata columns"""
         for r in rows:
             for md_c in METADATA_COLUMNS:
                 assert md_c in r
-
 
     def assert_metadata_columns_not_exist(self, rows):
         """This is a helper assertion that checks metadata columns don't exist in any row"""
@@ -67,16 +64,17 @@ class TestTargetRedshift(object):
             for md_c in METADATA_COLUMNS:
                 assert md_c not in r
 
-
-    def assert_three_streams_are_loaded_in_redshift(self, should_metadata_columns_exist=False, should_hard_deleted_rows=False):
+    def assert_three_streams_are_loaded_in_redshift(
+        self, should_metadata_columns_exist=False, should_hard_deleted_rows=False
+    ):
         """
         This is a helper assertion that checks if every data from the message-with-three-streams.json
         file is available in Redshift tables correctly.
         Useful to check different loading methods without duplicating assertions
         """
         redshift = DbSync(self.config)
-        default_target_schema = self.config.get('default_target_schema', '')
-        schema_mapping = self.config.get('schema_mapping', {})
+        default_target_schema = self.config.get("default_target_schema", "")
+        schema_mapping = self.config.get("schema_mapping", {})
 
         # Identify target schema name
         target_schema = None
@@ -86,17 +84,20 @@ class TestTargetRedshift(object):
             target_schema = "tap_mysql_test"
 
         # Get loaded rows from tables
-        table_one = redshift.query("SELECT * FROM {}.test_table_one ORDER BY c_pk".format(target_schema))
-        table_two = redshift.query("SELECT * FROM {}.test_table_two ORDER BY c_pk".format(target_schema))
-        table_three = redshift.query("SELECT * FROM {}.test_table_three ORDER BY c_pk".format(target_schema))
-
+        table_one = redshift.query(
+            "SELECT * FROM {}.test_table_one ORDER BY c_pk".format(target_schema)
+        )
+        table_two = redshift.query(
+            "SELECT * FROM {}.test_table_two ORDER BY c_pk".format(target_schema)
+        )
+        table_three = redshift.query(
+            "SELECT * FROM {}.test_table_three ORDER BY c_pk".format(target_schema)
+        )
 
         # ----------------------------------------------------------------------
         # Check rows in table_one
         # ----------------------------------------------------------------------
-        expected_table_one = [
-            {'c_int': 1, 'c_pk': 1, 'c_varchar': '1'}
-        ]
+        expected_table_one = [{"c_int": 1, "c_pk": 1, "c_varchar": "1"}]
 
         assert self.remove_metadata_columns_from_rows(table_one) == expected_table_one
 
@@ -106,12 +107,27 @@ class TestTargetRedshift(object):
         expected_table_two = []
         if not should_hard_deleted_rows:
             expected_table_two = [
-                {'c_int': 1, 'c_pk': 1, 'c_varchar': '1', 'c_date': datetime.datetime(2019, 2, 1, 15, 12, 45)},
-                {'c_int': 2, 'c_pk': 2, 'c_varchar': '2', 'c_date': datetime.datetime(2019, 2, 10, 2, 0, 0)}
+                {
+                    "c_int": 1,
+                    "c_pk": 1,
+                    "c_varchar": "1",
+                    "c_date": datetime.datetime(2019, 2, 1, 15, 12, 45),
+                },
+                {
+                    "c_int": 2,
+                    "c_pk": 2,
+                    "c_varchar": "2",
+                    "c_date": datetime.datetime(2019, 2, 10, 2, 0, 0),
+                },
             ]
         else:
             expected_table_two = [
-                {'c_int': 2, 'c_pk': 2, 'c_varchar': '2', 'c_date': datetime.datetime(2019, 2, 10, 2, 0, 0)}
+                {
+                    "c_int": 2,
+                    "c_pk": 2,
+                    "c_varchar": "2",
+                    "c_date": datetime.datetime(2019, 2, 10, 2, 0, 0),
+                }
             ]
 
         assert self.remove_metadata_columns_from_rows(table_two) == expected_table_two
@@ -122,17 +138,19 @@ class TestTargetRedshift(object):
         expected_table_three = []
         if not should_hard_deleted_rows:
             expected_table_three = [
-                    {'c_int': 1, 'c_pk': 1, 'c_varchar': '1', 'c_time': '04:00:00'},
-                    {'c_int': 2, 'c_pk': 2, 'c_varchar': '2', 'c_time': '07:15:00'},
-                    {'c_int': 3, 'c_pk': 3, 'c_varchar': '3', 'c_time': '23:00:03'}
+                {"c_int": 1, "c_pk": 1, "c_varchar": "1", "c_time": "04:00:00"},
+                {"c_int": 2, "c_pk": 2, "c_varchar": "2", "c_time": "07:15:00"},
+                {"c_int": 3, "c_pk": 3, "c_varchar": "3", "c_time": "23:00:03"},
             ]
         else:
             expected_table_three = [
-                {'c_int': 1, 'c_pk': 1, 'c_varchar': '1', 'c_time': '04:00:00'},
-                {'c_int': 2, 'c_pk': 2, 'c_varchar': '2', 'c_time': '07:15:00'}
+                {"c_int": 1, "c_pk": 1, "c_varchar": "1", "c_time": "04:00:00"},
+                {"c_int": 2, "c_pk": 2, "c_varchar": "2", "c_time": "07:15:00"},
             ]
 
-        assert self.remove_metadata_columns_from_rows(table_three) == expected_table_three
+        assert (
+            self.remove_metadata_columns_from_rows(table_three) == expected_table_three
+        )
 
         # ----------------------------------------------------------------------
         # Check if metadata columns exist or not
@@ -146,231 +164,296 @@ class TestTargetRedshift(object):
             self.assert_metadata_columns_not_exist(table_two)
             self.assert_metadata_columns_not_exist(table_three)
 
-
     def test_invalid_json(self):
         """Receiving invalid JSONs should raise an exception"""
-        tap_lines = test_utils.get_test_tap_lines('invalid-json.json')
+        tap_lines = test_utils.get_test_tap_lines("invalid-json.json")
         with pytest.raises(json.decoder.JSONDecodeError):
             target_redshift.persist_lines(self.config, tap_lines)
 
-
     def test_message_order(self):
         """RECORD message without a previously received SCHEMA message should raise an exception"""
-        tap_lines = test_utils.get_test_tap_lines('invalid-message-order.json')
+        tap_lines = test_utils.get_test_tap_lines("invalid-message-order.json")
         with pytest.raises(Exception):
             target_redshift.persist_lines(self.config, tap_lines)
 
-
     def test_loading_tables(self):
         """Loading multiple tables from the same input tap with various columns types"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
 
         # Turning off client-side encryption and load
-        self.config['client_side_encryption_master_key'] = ''
+        self.config["client_side_encryption_master_key"] = ""
         target_redshift.persist_lines(self.config, tap_lines)
 
         self.assert_three_streams_are_loaded_in_redshift()
-
 
     def test_loading_tables_with_metadata_columns(self):
         """Loading multiple tables from the same input tap with various columns types"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
 
         # Turning on adding metadata columns
-        self.config['add_metadata_columns'] = True
-        target_redshift.persist_lines(self.config, tap_lines)
-
-        # Check if data loaded correctly and metadata columns exist
-        self.assert_three_streams_are_loaded_in_redshift(should_metadata_columns_exist=True)
-
-
-    def test_loading_tables_with_defined_parallelism(self):
-        """Loading multiple tables from the same input tap with various columns types"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
-
-        # Turning on adding metadata columns
-        self.config['parallelism'] = 1
-        target_redshift.persist_lines(self.config, tap_lines)
-
-        self.assert_three_streams_are_loaded_in_redshift()
-
-
-    def test_loading_tables_with_hard_delete(self):
-        """Loading multiple tables from the same input tap with deleted rows"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
-
-        # Turning on hard delete mode
-        self.config['hard_delete'] = True
+        self.config["add_metadata_columns"] = True
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Check if data loaded correctly and metadata columns exist
         self.assert_three_streams_are_loaded_in_redshift(
-            should_metadata_columns_exist=True,
-            should_hard_deleted_rows=True
+            should_metadata_columns_exist=True
         )
 
+    def test_loading_tables_with_defined_parallelism(self):
+        """Loading multiple tables from the same input tap with various columns types"""
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
+
+        # Turning on adding metadata columns
+        self.config["parallelism"] = 1
+        target_redshift.persist_lines(self.config, tap_lines)
+
+        self.assert_three_streams_are_loaded_in_redshift()
+
+    def test_loading_tables_with_hard_delete(self):
+        """Loading multiple tables from the same input tap with deleted rows"""
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
+
+        # Turning on hard delete mode
+        self.config["hard_delete"] = True
+        target_redshift.persist_lines(self.config, tap_lines)
+
+        # Check if data loaded correctly and metadata columns exist
+        self.assert_three_streams_are_loaded_in_redshift(
+            should_metadata_columns_exist=True, should_hard_deleted_rows=True
+        )
 
     def test_loading_with_multiple_schema(self):
         """Loading table with multiple SCHEMA messages"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-multi-schemas.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-multi-schemas.json")
 
         # Load with default settings
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Check if data loaded correctly
         self.assert_three_streams_are_loaded_in_redshift(
-            should_metadata_columns_exist=False,
-            should_hard_deleted_rows=False
+            should_metadata_columns_exist=False, should_hard_deleted_rows=False
         )
-
 
     def test_loading_unicode_characters(self):
         """Loading unicode encoded characters"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-unicode-characters.json')
+        tap_lines = test_utils.get_test_tap_lines(
+            "messages-with-unicode-characters.json"
+        )
 
         # Load with default settings
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Get loaded rows from tables
         redshift = DbSync(self.config)
-        target_schema = self.config.get('default_target_schema', '')
-        table_unicode = redshift.query("SELECT * FROM {}.test_table_unicode ORDER BY c_pk".format(target_schema))
+        target_schema = self.config.get("default_target_schema", "")
+        table_unicode = redshift.query(
+            "SELECT * FROM {}.test_table_unicode ORDER BY c_pk".format(target_schema)
+        )
 
-        assert \
-            self.remove_metadata_columns_from_rows(table_unicode) == \
-            [
-                    {'c_int': 1, 'c_pk': 1, 'c_varchar': 'Hello world, Καλημέρα κόσμε, コンニチハ'},
-                    {'c_int': 2, 'c_pk': 2, 'c_varchar': 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.'},
-                    {'c_int': 3, 'c_pk': 3, 'c_varchar': 'Russian: Зарегистрируйтесь сейчас на Десятую Международную Конференцию по'},
-                    {'c_int': 4, 'c_pk': 4, 'c_varchar': 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช'},
-                    {'c_int': 5, 'c_pk': 5, 'c_varchar': 'Arabic: لقد لعبت أنت وأصدقاؤك لمدة وحصلتم علي من إجمالي النقاط'},
-                    {'c_int': 6, 'c_pk': 6, 'c_varchar': 'Special Characters: ["\\,\'!@£$%^&*()]\\\\'}
-            ]
-
+        assert self.remove_metadata_columns_from_rows(table_unicode) == [
+            {"c_int": 1, "c_pk": 1, "c_varchar": "Hello world, Καλημέρα κόσμε, コンニチハ"},
+            {
+                "c_int": 2,
+                "c_pk": 2,
+                "c_varchar": "Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.",
+            },
+            {
+                "c_int": 3,
+                "c_pk": 3,
+                "c_varchar": "Russian: Зарегистрируйтесь сейчас на Десятую Международную Конференцию по",
+            },
+            {
+                "c_int": 4,
+                "c_pk": 4,
+                "c_varchar": "Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช",
+            },
+            {
+                "c_int": 5,
+                "c_pk": 5,
+                "c_varchar": "Arabic: لقد لعبت أنت وأصدقاؤك لمدة وحصلتم علي من إجمالي النقاط",
+            },
+            {
+                "c_int": 6,
+                "c_pk": 6,
+                "c_varchar": "Special Characters: [\"\\,'!@£$%^&*()]\\\\",
+            },
+        ]
 
     def test_loading_long_text(self):
         """Loading long texts"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-long-texts.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-long-texts.json")
 
         # Load with default settings
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Get loaded rows from tables
         redshift = DbSync(self.config)
-        target_schema = self.config.get('default_target_schema', '')
-        table_long_texts = redshift.query("SELECT * FROM {}.test_table_long_texts ORDER BY c_pk".format(target_schema))
+        target_schema = self.config.get("default_target_schema", "")
+        table_long_texts = redshift.query(
+            "SELECT * FROM {}.test_table_long_texts ORDER BY c_pk".format(target_schema)
+        )
 
         # Test not very long texts by exact match
-        assert \
-            self.remove_metadata_columns_from_rows(table_long_texts)[:3] == \
-            [
-                    {'c_int': 1, 'c_pk': 1, 'c_varchar': 'Up to 128 characters: Lorem ipsum dolor sit amet, consectetuer adipiscing elit.'},
-                    {'c_int': 2, 'c_pk': 2, 'c_varchar': 'Up to 256 characters: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies.'},
-                    {'c_int': 3, 'c_pk': 3, 'c_varchar': 'Up to 1024 characters: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum.'},
-            ]
+        assert self.remove_metadata_columns_from_rows(table_long_texts)[:3] == [
+            {
+                "c_int": 1,
+                "c_pk": 1,
+                "c_varchar": "Up to 128 characters: Lorem ipsum dolor sit amet, consectetuer adipiscing elit.",
+            },
+            {
+                "c_int": 2,
+                "c_pk": 2,
+                "c_varchar": "Up to 256 characters: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies.",
+            },
+            {
+                "c_int": 3,
+                "c_pk": 3,
+                "c_varchar": "Up to 1024 characters: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum.",
+            },
+        ]
 
         # Test very long texts by string length
         record_4k = table_long_texts[3]
         record_32k = table_long_texts[4]
-        assert \
-            [
-                {'c_int': int(record_4k.get('c_int')), 'c_pk': int(record_4k.get('c_pk')), 'len': len(record_4k.get('c_varchar'))},
-                {'c_int': int(record_32k.get('c_int')), 'c_pk': int(record_32k.get('c_pk')), 'len': len(record_32k.get('c_varchar'))},
-            ] == \
-            [
-                {'c_int': 4, 'c_pk': 4, 'len': 4017},
-                {'c_int': 5, 'c_pk': 5, 'len': 32002},
-            ]
-
+        assert [
+            {
+                "c_int": int(record_4k.get("c_int")),
+                "c_pk": int(record_4k.get("c_pk")),
+                "len": len(record_4k.get("c_varchar")),
+            },
+            {
+                "c_int": int(record_32k.get("c_int")),
+                "c_pk": int(record_32k.get("c_pk")),
+                "len": len(record_32k.get("c_varchar")),
+            },
+        ] == [
+            {"c_int": 4, "c_pk": 4, "len": 4017},
+            {"c_int": 5, "c_pk": 5, "len": 32002},
+        ]
 
     def test_non_db_friendly_columns(self):
         """Loading non-db friendly columns like, camelcase, minus signs, etc."""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-non-db-friendly-columns.json')
+        tap_lines = test_utils.get_test_tap_lines(
+            "messages-with-non-db-friendly-columns.json"
+        )
 
         # Load with default settings
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Get loaded rows from tables
         redshift = DbSync(self.config)
-        target_schema = self.config.get('default_target_schema', '')
-        table_non_db_friendly_columns = redshift.query("SELECT * FROM {}.test_table_non_db_friendly_columns ORDER BY c_pk".format(target_schema))
+        target_schema = self.config.get("default_target_schema", "")
+        table_non_db_friendly_columns = redshift.query(
+            "SELECT * FROM {}.test_table_non_db_friendly_columns ORDER BY c_pk".format(
+                target_schema
+            )
+        )
 
-        assert \
-            self.remove_metadata_columns_from_rows(table_non_db_friendly_columns) == \
-            [
-                    {'c_pk': 1, 'camelcasecolumn': 'Dummy row 1', 'minus-column': 'Dummy row 1'},
-                    {'c_pk': 2, 'camelcasecolumn': 'Dummy row 2', 'minus-column': 'Dummy row 2'},
-                    {'c_pk': 3, 'camelcasecolumn': 'Dummy row 3', 'minus-column': 'Dummy row 3'},
-                    {'c_pk': 4, 'camelcasecolumn': 'Dummy row 4', 'minus-column': 'Dummy row 4'},
-                    {'c_pk': 5, 'camelcasecolumn': 'Dummy row 5', 'minus-column': 'Dummy row 5'},
-            ]
-
+        assert self.remove_metadata_columns_from_rows(
+            table_non_db_friendly_columns
+        ) == [
+            {
+                "c_pk": 1,
+                "camelcasecolumn": "Dummy row 1",
+                "minus-column": "Dummy row 1",
+            },
+            {
+                "c_pk": 2,
+                "camelcasecolumn": "Dummy row 2",
+                "minus-column": "Dummy row 2",
+            },
+            {
+                "c_pk": 3,
+                "camelcasecolumn": "Dummy row 3",
+                "minus-column": "Dummy row 3",
+            },
+            {
+                "c_pk": 4,
+                "camelcasecolumn": "Dummy row 4",
+                "minus-column": "Dummy row 4",
+            },
+            {
+                "c_pk": 5,
+                "camelcasecolumn": "Dummy row 5",
+                "minus-column": "Dummy row 5",
+            },
+        ]
 
     def test_nested_schema_unflattening(self):
         """Loading nested JSON objects into VARIANT columns without flattening"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-nested-schema.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-nested-schema.json")
 
         # Load with default settings - Flattening disabled
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Get loaded rows from tables - Transform JSON to string at query time
         redshift = DbSync(self.config)
-        target_schema = self.config.get('default_target_schema', '')
-        unflattened_table = redshift.query("""
+        target_schema = self.config.get("default_target_schema", "")
+        unflattened_table = redshift.query(
+            """
             SELECT c_pk
                   ,c_array
                   ,c_object
                   ,c_object_with_props
                   ,c_nested_object
               FROM {}.test_table_nested_schema
-             ORDER BY c_pk""".format(target_schema))
+             ORDER BY c_pk""".format(
+                target_schema
+            )
+        )
 
         # Should be valid nested JSON strings
-        assert \
-            self.remove_metadata_columns_from_rows(unflattened_table) == \
-            [{
-                'c_pk': 1,
-                'c_array': '[1, 2, 3]',
-                'c_object': '{"key_1": "value_1"}',
-                'c_object_with_props': '{"key_1": "value_1"}',
-                'c_nested_object': '{"nested_prop_1": "nested_value_1", "nested_prop_2": "nested_value_2", "nested_prop_3": {"multi_nested_prop_1": "multi_value_1", "multi_nested_prop_2": "multi_value_2"}}'
-            }]
-
+        assert self.remove_metadata_columns_from_rows(unflattened_table) == [
+            {
+                "c_pk": 1,
+                "c_array": "[1, 2, 3]",
+                "c_object": '{"key_1": "value_1"}',
+                "c_object_with_props": '{"key_1": "value_1"}',
+                "c_nested_object": '{"nested_prop_1": "nested_value_1", "nested_prop_2": "nested_value_2", "nested_prop_3": {"multi_nested_prop_1": "multi_value_1", "multi_nested_prop_2": "multi_value_2"}}',
+            }
+        ]
 
     def test_nested_schema_flattening(self):
         """Loading nested JSON objects with flattening and not not flattening"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-nested-schema.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-nested-schema.json")
 
         # Turning on data flattening
-        self.config['data_flattening_max_level'] = 10
+        self.config["data_flattening_max_level"] = 10
 
         # Load with default settings - Flattening disabled
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Get loaded rows from tables
         redshift = DbSync(self.config)
-        target_schema = self.config.get('default_target_schema', '')
-        flattened_table = redshift.query("SELECT * FROM {}.test_table_nested_schema ORDER BY c_pk".format(target_schema))
+        target_schema = self.config.get("default_target_schema", "")
+        flattened_table = redshift.query(
+            "SELECT * FROM {}.test_table_nested_schema ORDER BY c_pk".format(
+                target_schema
+            )
+        )
 
         # Should be flattened columns
-        assert \
-            self.remove_metadata_columns_from_rows(flattened_table) == \
-            [{
-                'c_pk': 1,
-                'c_array': '[1, 2, 3]',
-                'c_object': None,   # Cannot map RECORD to SCHEMA. SCHEMA doesn't have properties that requires for flattening
-                'c_object_with_props__key_1': 'value_1',
-                'c_nested_object__nested_prop_1': 'nested_value_1',
-                'c_nested_object__nested_prop_2': 'nested_value_2',
-                'c_nested_object__nested_prop_3__multi_nested_prop_1': 'multi_value_1',
-                'c_nested_object__nested_prop_3__multi_nested_prop_2': 'multi_value_2',
-            }]
-
+        assert self.remove_metadata_columns_from_rows(flattened_table) == [
+            {
+                "c_pk": 1,
+                "c_array": "[1, 2, 3]",
+                "c_object": None,  # Cannot map RECORD to SCHEMA. SCHEMA doesn't have properties that requires for flattening
+                "c_object_with_props__key_1": "value_1",
+                "c_nested_object__nested_prop_1": "nested_value_1",
+                "c_nested_object__nested_prop_2": "nested_value_2",
+                "c_nested_object__nested_prop_3__multi_nested_prop_1": "multi_value_1",
+                "c_nested_object__nested_prop_3__multi_nested_prop_2": "multi_value_2",
+            }
+        ]
 
     def test_column_name_change(self):
         """Tests correct renaming of redshift columns after source change"""
-        tap_lines_before_column_name_change = test_utils.get_test_tap_lines('messages-with-three-streams.json')
-        tap_lines_after_column_name_change = test_utils.get_test_tap_lines('messages-with-three-streams-modified-column.json')
+        tap_lines_before_column_name_change = test_utils.get_test_tap_lines(
+            "messages-with-three-streams.json"
+        )
+        tap_lines_after_column_name_change = test_utils.get_test_tap_lines(
+            "messages-with-three-streams-modified-column.json"
+        )
 
         # Load with default settings
         target_redshift.persist_lines(self.config, tap_lines_before_column_name_change)
@@ -378,13 +461,20 @@ class TestTargetRedshift(object):
 
         # Get loaded rows from tables
         redshift = DbSync(self.config)
-        target_schema = self.config.get('default_target_schema', '')
-        table_one = redshift.query("SELECT * FROM {}.test_table_one ORDER BY c_pk".format(target_schema))
-        table_two = redshift.query("SELECT * FROM {}.test_table_two ORDER BY c_pk".format(target_schema))
-        table_three = redshift.query("SELECT * FROM {}.test_table_three ORDER BY c_pk".format(target_schema))
+        target_schema = self.config.get("default_target_schema", "")
+        table_one = redshift.query(
+            "SELECT * FROM {}.test_table_one ORDER BY c_pk".format(target_schema)
+        )
+        table_two = redshift.query(
+            "SELECT * FROM {}.test_table_two ORDER BY c_pk".format(target_schema)
+        )
+        table_three = redshift.query(
+            "SELECT * FROM {}.test_table_three ORDER BY c_pk".format(target_schema)
+        )
 
         # Get the previous column name from information schema in test_table_two
-        previous_column_name = redshift.query("""
+        previous_column_name = redshift.query(
+            """
             SELECT column_name
               FROM information_schema.columns
              WHERE table_catalog = '{}'
@@ -393,44 +483,82 @@ class TestTargetRedshift(object):
              ORDER BY ordinal_position
              LIMIT 1
             """.format(
-                self.config.get('dbname', '').lower(),
-                target_schema.lower()))[0]["column_name"]
+                self.config.get("dbname", "").lower(), target_schema.lower()
+            )
+        )[0]["column_name"]
 
         # Table one should have no changes
-        assert \
-            self.remove_metadata_columns_from_rows(table_one) == \
-            [{'c_int': 1, 'c_pk': 1, 'c_varchar': '1'}]
+        assert self.remove_metadata_columns_from_rows(table_one) == [
+            {"c_int": 1, "c_pk": 1, "c_varchar": "1"}
+        ]
 
         # Table two should have versioned column
-        assert \
-            self.remove_metadata_columns_from_rows(table_two) == \
-            [
-                {previous_column_name: datetime.datetime(2019, 2, 1, 15, 12, 45), 'c_int': 1, 'c_pk': 1, 'c_varchar': '1', 'c_date': None},
-                {previous_column_name: datetime.datetime(2019, 2, 10, 2), 'c_int': 2, 'c_pk': 2, 'c_varchar': '2', 'c_date': '2019-02-12 02:00:00'},
-                {previous_column_name: None, 'c_int': 3, 'c_pk': 3, 'c_varchar': '2', 'c_date': '2019-02-15 02:00:00'}
-            ]
+        assert self.remove_metadata_columns_from_rows(table_two) == [
+            {
+                previous_column_name: datetime.datetime(2019, 2, 1, 15, 12, 45),
+                "c_int": 1,
+                "c_pk": 1,
+                "c_varchar": "1",
+                "c_date": None,
+            },
+            {
+                previous_column_name: datetime.datetime(2019, 2, 10, 2),
+                "c_int": 2,
+                "c_pk": 2,
+                "c_varchar": "2",
+                "c_date": "2019-02-12 02:00:00",
+            },
+            {
+                previous_column_name: None,
+                "c_int": 3,
+                "c_pk": 3,
+                "c_varchar": "2",
+                "c_date": "2019-02-15 02:00:00",
+            },
+        ]
 
         # Table three should have renamed columns
-        assert \
-            self.remove_metadata_columns_from_rows(table_three) == \
-            [
-                {'c_int': 1, 'c_pk': 1, 'c_time': '04:00:00', 'c_varchar': '1', 'c_time_renamed': None},
-                {'c_int': 2, 'c_pk': 2, 'c_time': '07:15:00', 'c_varchar': '2', 'c_time_renamed': None},
-                {'c_int': 3, 'c_pk': 3, 'c_time': '23:00:03', 'c_varchar': '3', 'c_time_renamed': '08:15:00'},
-                {'c_int': 4, 'c_pk': 4, 'c_time': None, 'c_varchar': '4', 'c_time_renamed': '23:00:03'}
-            ]
-
+        assert self.remove_metadata_columns_from_rows(table_three) == [
+            {
+                "c_int": 1,
+                "c_pk": 1,
+                "c_time": "04:00:00",
+                "c_varchar": "1",
+                "c_time_renamed": None,
+            },
+            {
+                "c_int": 2,
+                "c_pk": 2,
+                "c_time": "07:15:00",
+                "c_varchar": "2",
+                "c_time_renamed": None,
+            },
+            {
+                "c_int": 3,
+                "c_pk": 3,
+                "c_time": "23:00:03",
+                "c_varchar": "3",
+                "c_time_renamed": "08:15:00",
+            },
+            {
+                "c_int": 4,
+                "c_pk": 4,
+                "c_time": None,
+                "c_varchar": "4",
+                "c_time_renamed": "23:00:03",
+            },
+        ]
 
     def test_grant_privileges(self):
         """Tests GRANT USAGE and SELECT privileges on newly created tables"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
 
         # Create test users and groups
         redshift = DbSync(self.config)
         redshift.query("DROP USER IF EXISTS user_1")
         redshift.query("DROP USER IF EXISTS user_2")
         try:
-            redshift.query("DROP GROUP group_1") # DROP GROUP has no IF EXISTS
+            redshift.query("DROP GROUP group_1")  # DROP GROUP has no IF EXISTS
         except:
             pass
         try:
@@ -443,83 +571,124 @@ class TestTargetRedshift(object):
         redshift.query("CREATE GROUP group_2 WITH USER user_2")
 
         # When grantees is a string then privileges should be granted to single user
-        redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
-        self.config['default_target_schema_select_permissions'] = 'user_1'
+        redshift.query(
+            "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                self.config["default_target_schema"]
+            )
+        )
+        self.config["default_target_schema_select_permissions"] = "user_1"
         target_redshift.persist_lines(self.config, tap_lines)
 
         # When grantees is a list then privileges should be granted to list of user
-        redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
-        self.config['default_target_schema_select_permissions'] = ['user_1', 'user_2']
+        redshift.query(
+            "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                self.config["default_target_schema"]
+            )
+        )
+        self.config["default_target_schema_select_permissions"] = ["user_1", "user_2"]
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Grant privileges to list of users
-        redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
-        self.config['default_target_schema_select_permissions'] = {'users': ['user_1', 'user_2']}
+        redshift.query(
+            "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                self.config["default_target_schema"]
+            )
+        )
+        self.config["default_target_schema_select_permissions"] = {
+            "users": ["user_1", "user_2"]
+        }
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Grant privileges to list of groups
-        redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
-        self.config['default_target_schema_select_permissions'] = {'groups': ['group_1', 'group_2']}
+        redshift.query(
+            "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                self.config["default_target_schema"]
+            )
+        )
+        self.config["default_target_schema_select_permissions"] = {
+            "groups": ["group_1", "group_2"]
+        }
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Grant privileges to mix of list of users and groups
-        redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
-        self.config['default_target_schema_select_permissions'] = {
-            'users': ['user_1', 'user_2'],
-            'groups': ['group_1', 'group_2']}
+        redshift.query(
+            "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                self.config["default_target_schema"]
+            )
+        )
+        self.config["default_target_schema_select_permissions"] = {
+            "users": ["user_1", "user_2"],
+            "groups": ["group_1", "group_2"],
+        }
         target_redshift.persist_lines(self.config, tap_lines)
 
         # Granting not existing user should raise exception
-        redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
+        redshift.query(
+            "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                self.config["default_target_schema"]
+            )
+        )
         with pytest.raises(Exception):
-            self.config['default_target_schema_select_permissions'] = {'users': ['user_not_exists_1', 'user_not_exists_2']}
+            self.config["default_target_schema_select_permissions"] = {
+                "users": ["user_not_exists_1", "user_not_exists_2"]
+            }
             target_redshift.persist_lines(self.config, tap_lines)
 
         # Granting not existing group should raise exception
-        redshift.query("DROP SCHEMA IF EXISTS {} CASCADE".format(self.config['default_target_schema']))
+        redshift.query(
+            "DROP SCHEMA IF EXISTS {} CASCADE".format(
+                self.config["default_target_schema"]
+            )
+        )
         with pytest.raises(Exception):
-            self.config['default_target_schema_select_permissions'] = {'groups': ['group_not_exists_1', 'group_not_exists_2']}
+            self.config["default_target_schema_select_permissions"] = {
+                "groups": ["group_not_exists_1", "group_not_exists_2"]
+            }
             target_redshift.persist_lines(self.config, tap_lines)
-
 
     def test_custom_copy_options(self):
         """Test loading data with custom copy options"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
 
         # Loading with identical copy option should pass
-        self.config['copy_options'] = 'EMPTYASNULL TRIMBLANKS FILLRECORD TRUNCATECOLUMNS'
+        self.config[
+            "copy_options"
+        ] = "EMPTYASNULL TRIMBLANKS FILLRECORD TRUNCATECOLUMNS"
         target_redshift.persist_lines(self.config, tap_lines)
-
 
     def test_copy_using_aws_environment(self):
         """Test loading data with aws in the environment rather than explicitly provided access keys"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
 
         try:
-            os.environ["AWS_ACCESS_KEY_ID"] = os.environ.get('TARGET_REDSHIFT_AWS_ACCESS_KEY')
-            os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ.get('TARGET_REDSHIFT_AWS_SECRET_ACCESS_KEY')
-            config['aws_access_key_id'] = None
-            config['aws_secret_access_key'] = None
+            os.environ["AWS_ACCESS_KEY_ID"] = os.environ.get(
+                "TARGET_REDSHIFT_AWS_ACCESS_KEY"
+            )
+            os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ.get(
+                "TARGET_REDSHIFT_AWS_SECRET_ACCESS_KEY"
+            )
+            self.config["aws_access_key_id"] = None
+            self.config["aws_secret_access_key"] = None
 
             target_redshift.persist_lines(self.config, tap_lines)
         finally:
             del os.environ["AWS_ACCESS_KEY_ID"]
             del os.environ["AWS_SECRET_ACCESS_KEY"]
 
-
     def test_copy_using_role_arn(self):
         """Test loading data with aws role arn rather than aws access keys"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
 
-        self.config['aws_redshift_copy_role_arn'] = os.environ.get('TARGET_REDSHIFT_AWS_REDSHIFT_COPY_ROLE_ARN')
+        self.config["aws_redshift_copy_role_arn"] = os.environ.get(
+            "TARGET_REDSHIFT_AWS_REDSHIFT_COPY_ROLE_ARN"
+        )
         target_redshift.persist_lines(self.config, tap_lines)
-
 
     def test_invalid_custom_copy_options(self):
         """Tests loading data with custom copy options"""
-        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
 
         # Loading with invalid custom copy option should raise exception
-        self.config['copy_options'] = '_INVALID_COPY_OPTION_'
+        self.config["copy_options"] = "_INVALID_COPY_OPTION_"
         with pytest.raises(Exception):
             target_redshift.persist_lines(self.config, tap_lines)

--- a/tests/integration/test_target_redshift.py
+++ b/tests/integration/test_target_redshift.py
@@ -491,6 +491,30 @@ class TestTargetRedshift(object):
         target_redshift.persist_lines(self.config, tap_lines)
 
 
+    def test_copy_using_aws_environment(self):
+        """Test loading data with aws in the environment rather than explicitly provided access keys"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+
+        try:
+            os.environ["AWS_ACCESS_KEY_ID"] = os.environ.get('TARGET_REDSHIFT_AWS_ACCESS_KEY')
+            os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ.get('TARGET_REDSHIFT_AWS_SECRET_ACCESS_KEY')
+            config['aws_access_key_id'] = None
+            config['aws_secret_access_key'] = None
+
+            target_redshift.persist_lines(self.config, tap_lines)
+        finally:
+            del os.environ["AWS_ACCESS_KEY_ID"]
+            del os.environ["AWS_SECRET_ACCESS_KEY"]
+
+
+    def test_copy_using_role_arn(self):
+        """Test loading data with aws role arn rather than aws access keys"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+
+        self.config['aws_redshift_copy_role_arn'] = os.environ.get('TARGET_REDSHIFT_AWS_REDSHIFT_COPY_ROLE_ARN')
+        target_redshift.persist_lines(self.config, tap_lines)
+
+
     def test_invalid_custom_copy_options(self):
         """Tests loading data with custom copy options"""
         tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
@@ -499,4 +523,3 @@ class TestTargetRedshift(object):
         self.config['copy_options'] = '_INVALID_COPY_OPTION_'
         with pytest.raises(Exception):
             target_redshift.persist_lines(self.config, tap_lines)
-

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -34,6 +34,7 @@ def get_db_config():
     config['schema_mapping'] = None
     config['add_metadata_columns'] = None
     config['hard_delete'] = None
+    config['aws_redshift_copy_role_arn'] = None
 
 
     return config


### PR DESCRIPTION
This change allows boto3 to search for credentials automatically if an access and secret key are not provided.

This allows the target to use environment, EC2, ECS or credentials from an AWS_PROFILE file if present, rather than forcing them to be passed explicitly. Credentials will still be used by default if provided, but they are no longer required.

Added an option to explictly pass credentials for use in the `COPY` operation, this allows a different role arn to be used than that fetched from the credentials chain.

This requires a role to be setup for the integration tests which can be used by `COPY`, set to `TARGET_REDSHIFT_AWS_REDSHIFT_COPY_ROLE_ARN`.

Tested getting credentials locally using an `~/.aws/credentials` file and `AWS_PROFILE` environment variable, so other mechanisms should also work.

N.B this change means that the target will fail when trying to perform S3 operations for the first time if credentials are missing, rather than on instantiation. If failing fast is preferred I believe we could validate whether keys exist in the frozen credentials object.

Fixes https://github.com/transferwise/pipelinewise-target-redshift/issues/10