### PR TITLE
Fix for ECS credentials

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -213,12 +213,21 @@ class DbSync:
         self.connection_config = connection_config
         self.stream_schema_message = stream_schema_message
 
+        aws_access_key_id=self.connection_config.get('aws_access_key_id')
+        aws_secret_access_key=self.connection_config.get('aws_secret_access_key')
+        aws_session_token=self.connection_config.get('aws_session_token')
+
         # Init S3 client
-        aws_session = boto3.session.Session(
-            aws_access_key_id=self.connection_config.get('aws_access_key_id'),
-            aws_secret_access_key=self.connection_config.get('aws_secret_access_key'),
-            aws_session_token=self.connection_config.get('aws_session_token'),
-        )
+        # Conditionally pass keys as this seems to affect whether instance credentials are correctly loaded if the keys are None
+        if aws_access_key_id and aws_secret_access_key:
+            aws_session = boto3.session.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token
+            )
+        else:
+            aws_session = boto3.session.Session()
+
         credentials = aws_session.get_credentials().get_frozen_credentials()
 
         self.s3 = aws_session.client('s3')


### PR DESCRIPTION
Fix ECS credentials not being correctly picked up by boto3 when no keys are provided.

This is a fix I've applied in our production environment in order to use ECS  credentials rather than AWS keys. Without it boto3 could not find the credentials as expected.

I'm unsure why this is necessary - I've looked through the boto3 credentials code and I can't see anything which would mean that `None` values for the keys would result in ECS credentials not being used, and I _think_ EC2 instance credentials _are_ picked up without this change (hence not including this tweak in the original change I made).