### PR TITLE
Add 'slices' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Full list of options in `config.json`:
 | hard_delete                         | Boolean |            | (Default: False) When `hard_delete` option is true then DELETE SQL commands will be performed in Redshift to delete rows in tables. It's achieved by continuously checking the  `_SDC_DELETED_AT` metadata column sent by the singer tap. Due to deleting rows requires metadata columns, `hard_delete` option automatically enables the `add_metadata_columns` option as well. |
 | data_flattening_max_level           | Integer |            | (Default: 0) Object type RECORD items from taps can be loaded into VARIANT columns as JSON (default) or we can flatten the schema by creating columns automatically.<br><br>When value is 0 (default) then flattening functionality is turned off. |
 | primary_key_required                | Boolean |            | (Default: True) Log based and Incremental replications on tables with no Primary Key cause duplicates when merging UPDATE events. When set to true, stop loading data if no Primary Key is defined. |
+| slices                              | Integer |    No      | The number of slices to split files into prior to running COPY on Redshift. This should be set to the number of Redshift slices.
+The number of slices per node depends on the node size of the cluster - run `SELECT COUNT(DISTINCT slice) slices FROM stv_slices` to calculate this. Defaults to `1`. |
 
 ### To run tests:
 

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -299,6 +299,7 @@ def flush_streams(
     # Single-host, thread-based parallelism
     with parallel_backend('threading', n_jobs=parallelism):
         Parallel()(delayed(load_stream_batch)(
+            config=config,
             stream=stream,
             records_to_load=streams[stream],
             row_count=row_count,
@@ -328,10 +329,10 @@ def flush_streams(
     return flushed_state
 
 
-def load_stream_batch(stream, records_to_load, row_count, db_sync, delete_rows=False):
+def load_stream_batch(config, stream, records_to_load, row_count, db_sync, delete_rows=False):
     # Load into redshift
     if row_count[stream] > 0:
-        flush_records(stream, records_to_load, row_count[stream], db_sync)
+        flush_records(config, stream, records_to_load, row_count[stream], db_sync)
 
         # Delete soft-deleted, flagged rows - where _sdc_deleted at is not null
         if delete_rows:

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -13,6 +13,7 @@ from tempfile import NamedTemporaryFile, mkstemp
 import singer
 from joblib import Parallel, delayed, parallel_backend
 from jsonschema import Draft4Validator, FormatChecker
+from itertools import islice
 
 from target_redshift.db_sync import DbSync
 
@@ -340,17 +341,60 @@ def load_stream_batch(stream, records_to_load, row_count, db_sync, delete_rows=F
         row_count[stream] = 0
 
 
-def flush_records(stream, records_to_load, row_count, db_sync):
-    csv_fd, csv_file = mkstemp()
-    with open(csv_fd, 'w+b') as f:
-        for record in records_to_load.values():
-            csv_line = db_sync.record_to_csv_line(record)
-            f.write(bytes(csv_line + '\n', 'UTF-8'))
 
-    s3_key = db_sync.put_to_s3(csv_file, stream, row_count)
-    db_sync.load_csv(s3_key, row_count)
-    os.remove(csv_file)
-    db_sync.delete_from_s3(s3_key)
+def chunk_iterable(iterable, size):
+    """Yield successive n-sized chunks from iterable. The last chunk is not padded"""
+    iterable = iter(iterable)
+    return iter(lambda: tuple(islice(iterable, size)), ())
+
+
+def ceiling_division(n, d):
+    """Returns integer ceiling division of n / d"""
+    return -(n // -d)
+
+
+def flush_records(config, stream, records_to_load, row_count, db_sync):
+    file_extension = ".csv"
+    try:
+        slices = int(config.get("slices", 1))
+    except Exception as err:
+        logger.error("The provided configuration value 'slices' was not an integer")
+        raise err
+
+    csv_files = []
+    s3_keys = []
+
+    date_suffix = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+
+    # chunk files by the 'slices' config parameter in order to optimise Redshift COPY loading
+    # see https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-use-multiple-files.html
+    chunks = chunk_iterable(
+        list(records_to_load.values()), ceiling_division(len(records_to_load), slices)
+    )
+    for chunk_number, chunk in enumerate(chunks, start=1):
+        _, csv_file = mkstemp(suffix=file_extension + "." + str(chunk_number))
+        csv_files = csv_files + [csv_file]
+        with open(csv_file, "w+b") as csv_f:
+            for record in chunk:
+                csv_line = db_sync.record_to_csv_line(record)
+                csv_f.write(bytes(csv_line + "\n", "UTF-8"))
+        s3_key = db_sync.put_to_s3(
+            csv_file,
+            stream,
+            len(chunk),
+            suffix="_" + date_suffix + file_extension + "." + str(chunk_number),
+        )
+        s3_keys = s3_keys + [s3_key]
+
+    # the copy key is the filename prefix without the chunk number
+    copy_key = os.path.splitext(s3_keys[0])[0]
+
+    db_sync.load_csv(copy_key, row_count)
+    for csv_file in csv_files:
+        os.remove(csv_file)
+    for s3_key in s3_keys:
+        db_sync.delete_from_s3(s3_key)
+
 
 
 def main():

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -340,13 +340,13 @@ class DbSync:
         )
 
 
-    def put_to_s3(self, file, stream, count):
+    def put_to_s3(self, file, stream, count, suffix = ""):
         logger.info("Uploading {} rows to S3".format(count))
 
         # Generating key in S3 bucket
         bucket = self.connection_config['s3_bucket']
         s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
-        s3_key = "{}pipelinewise_{}_{}.csv".format(s3_key_prefix, stream, datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f"))
+        s3_key = "{}pipelinewise_{}{}".format(s3_key_prefix, stream, suffix)
 
         logger.info("Target S3 bucket: {}, local file: {}, S3 key: {}".format(bucket, file, s3_key))
 
@@ -411,7 +411,7 @@ class DbSync:
                     s3_bucket=self.connection_config['s3_bucket'],
                     s3_key=s3_key,
                     copy_credentials=copy_credentials,
-                    copy_options=copy_options
+                    copy_options=copy_options,
                 )
                 logger.debug("REDSHIFT - {}".format(copy_sql))
                 cur.execute(copy_sql)

--- a/tests/integration/test_target_redshift.py
+++ b/tests/integration/test_target_redshift.py
@@ -18,7 +18,7 @@ METADATA_COLUMNS = ["_sdc_extracted_at", "_sdc_batched_at", "_sdc_deleted_at"]
 
 class TestTargetRedshift(object):
     """
-    UnIntegrationit Tests for PipelineWise Target Redshift
+    Integration Tests for PipelineWise Target Redshift
     """
 
     def setup_method(self):
@@ -294,6 +294,15 @@ class TestTargetRedshift(object):
 
         # Using fixed 1 thread parallelism
         self.config["parallelism"] = 1
+        target_redshift.persist_lines(self.config, tap_lines)
+
+        self.assert_three_streams_are_loaded_in_redshift()
+
+    def test_loading_tables_with_defined_slice_number(self):
+        """Loading multiple tables from the same input tap with various columns types with a defined slice number"""
+        tap_lines = test_utils.get_test_tap_lines("messages-with-three-streams.json")
+
+        self.config["slices"] = 4
         target_redshift.persist_lines(self.config, tap_lines)
 
         self.assert_three_streams_are_loaded_in_redshift()


### PR DESCRIPTION
This allows the user to configure the number of chunks that files will be loaded in. This should improve parallel loading.

It may be sensible to also add a minimum chunk size, and a maximum chunk size. The recommended minimum/maximum sizes are 1MB/256MB compressed, however I'm not sure how to best implement this automatically in a quick and sensible way, especially after also adding compression.

Reference: https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-use-multiple-files.html