### PR TITLE
Prefer psycopg2-binary dependency over build from source; Match dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 singer-python==5.7.0
 boto3==1.9.188
-psycopg2==2.8.3
+psycopg2-binary==2.8.3
 inflection==0.3.1
 joblib==0.13.2

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name="pipelinewise-target-redshift",
       install_requires=[
           'singer-python==5.7.0',
           'boto3==1.9.188',
-          'psycopg2==2.7.7',
+          'psycopg2-binary==2.8.3',
           'inflection==0.3.1',
           'joblib==0.13.2'
       ],


### PR DESCRIPTION
I think this makes installation a bit easier. I'm not sure if it's preferred in this project or if there were any reasons not to use it.