### PR TITLE
Log inserts, updates and csv size_bytes

### DIFF
--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -380,6 +380,7 @@ def flush_records(stream, records_to_load, row_count, db_sync, compression=None,
 
     csv_files = []
     s3_keys = []
+    size_bytes = 0
 
     date_suffix = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
 
@@ -401,12 +402,13 @@ def flush_records(stream, records_to_load, row_count, db_sync, compression=None,
             len(chunk),
             suffix="_" + date_suffix + file_extension + "." + str(chunk_number),
         )
+        size_bytes += os.path.getsize(csv_file)
         s3_keys = s3_keys + [s3_key]
 
     # the copy key is the filename prefix without the chunk number
     copy_key = os.path.splitext(s3_keys[0])[0]
 
-    db_sync.load_csv(copy_key, row_count, compression)
+    db_sync.load_csv(copy_key, row_count, size_bytes, compression)
     for csv_file in csv_files:
         os.remove(csv_file)
     for s3_key in s3_keys:


### PR DESCRIPTION
Redshift equivalent of the Snowflake PR https://github.com/transferwise/pipelinewise-target-snowflake/pull/69

For better logging experience adding the csv file size to the logs and logging load stats in a more consumable JSON format:

```
time=2020-04-17 17:31:14 name=target_redshift level=INFO message=Loading into local_dev1."TEST_TABLE_THREE": {"inserts": 3, "updates": 0, "size_bytes": 57}
time=2020-04-17 17:31:14 name=target_redshift level=INFO message=Loading into local_dev1."TEST_TABLE_TWO": {"inserts": 2, "updates": 0, "size_bytes": 60}
time=2020-04-17 17:31:14 name=target_redshift level=INFO message=Loading into local_dev1."TEST_TABLE_ONE": {"inserts": 1, "updates": 0, "size_bytes": 8}
```