### PR TITLE
Add log message indicating which stream failed to load

### DIFF
--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -357,7 +357,7 @@ def load_stream_batch(stream, records_to_load, row_count, db_sync, delete_rows=F
             # reset row count for the current stream
             row_count[stream] = 0
     except Exception as e:
-        logger.exception("Failed to load stream %s to Redshift", stream)
+        LOGGER.exception("Failed to load stream %s to Redshift", stream)
         raise e
 
 def chunk_iterable(iterable, size):

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -345,17 +345,20 @@ def flush_streams(
 
 
 def load_stream_batch(stream, records_to_load, row_count, db_sync, delete_rows=False, compression=None, slices=None, temp_dir=None):
-    # Load into redshift
-    if row_count[stream] > 0:
-        flush_records(stream, records_to_load, row_count[stream], db_sync, compression, slices, temp_dir)
+    # Load into redshift                                            
+    try:
+        if row_count[stream] > 0:
+            flush_records(stream, records_to_load, row_count[stream], db_sync, compression, slices, temp_dir)
 
-        # Delete soft-deleted, flagged rows - where _sdc_deleted at is not null
-        if delete_rows:
-            db_sync.delete_rows(stream)
+            # Delete soft-deleted, flagged rows - where _sdc_deleted at is not null
+            if delete_rows:
+                db_sync.delete_rows(stream)
 
-        # reset row count for the current stream
-        row_count[stream] = 0
-
+            # reset row count for the current stream
+            row_count[stream] = 0
+    except Exception as e:
+        logger.exception("Failed to load stream %s to Redshift", stream)
+        raise e
 
 def chunk_iterable(iterable, size):
     """Yield successive n-sized chunks from iterable. The last chunk is not padded"""


### PR DESCRIPTION
We had issues working out which stream failed to load when hitting internal redshift errors

In this case:

```
psycopg2.InternalError: Value too long for character type
DETAIL:
  -----------------------------------------------
  error:  Value too long for character type
  code:      8001
  context:   Value too long for type character varying(505)
  query:     13569697
  location:  string.cpp:179
  process:   query2_117_13569697 [pid=20964]
  -----------------------------------------------
```

This should at least help give some context if loading multiple streams at once.