### PR TITLE
Update logging to output table name instead of schema name

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -737,5 +737,5 @@ class DbSync:
             self.logger.info("Table '{}' does not exist. Creating...".format(table_name_with_schema))
             self.create_table_and_grant_privilege()
         else:
-            self.logger.info("Table '{}' exists".format(self.schema_name))
+            self.logger.info("Table '{}' exists".format(table_name_with_schema))
             self.update_columns()


### PR DESCRIPTION
## Context

Looking at the logging message we should output the table name here instead of just the schema name. Like it's done on line 737

### Changes

updated the logging information to output the table name 

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
