### PR TITLE
Feat/escape hyphens

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -177,7 +177,7 @@ def stream_name_to_dict(stream_name, separator='-'):
     schema_name = None
     table_name = stream_name
 
-    # Schema and table name can be derived from stream if it's in <schema_nama>-<table_name> format
+    # Schema and table name can be derived from stream if it's in <schema_name>-<table_name> format
     s = stream_name.split(separator)
     if len(s) == 2:
         schema_name = s[0]
@@ -284,9 +284,9 @@ class DbSync:
             stream_name = stream_schema_message['stream']
             stream_schema_name = stream_name_to_dict(stream_name)['schema_name']
             if config_schema_mapping and stream_schema_name in config_schema_mapping:
-                self.schema_name = config_schema_mapping[stream_schema_name].get('target_schema')
+                self.schema_name = config_schema_mapping[stream_schema_name].get('target_schema').replace('-', '_')
             elif config_default_target_schema:
-                self.schema_name = config_default_target_schema
+                self.schema_name = config_default_target_schema.replace('-', '_')
 
             if not self.schema_name:
                 raise Exception("Target schema name not defined in config. Neither 'default_target_schema' (string) nor 'schema_mapping' (object) defines target schema for {} stream.".format(stream_name))


### PR DESCRIPTION
## Context
If a user has a hyphen in the org name, the flows break. We should escape hyphens to let users use hyphens in the org name.

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
