### PR TITLE
Support Python 3.10 and 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name="pipelinewise-target-redshift",
       install_requires=[
           'pipelinewise-singer-python==1.*',
           'boto3==1.12.39',
-          'psycopg2-binary==2.8.5',
+          'psycopg2-binary==2.9.5',
           'inflection==0.4.0',
           'joblib==0.16.0'
       ],

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -51,7 +51,9 @@ def column_type(schema_property, with_length=True):
     varchar_length = DEFAULT_VARCHAR_LENGTH
     if schema_property.get('maxLength', 0) > varchar_length:
         varchar_length = LONG_VARCHAR_LENGTH
-    if 'object' in property_type or 'array' in property_type:
+    if 'object' in property_type:
+        column_type = 'super'
+    if 'array' in property_type:
         column_type = 'character varying'
         varchar_length = LONG_VARCHAR_LENGTH
 

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import itertools
 import json
 import os
@@ -161,7 +161,7 @@ def flatten_record(d, flatten_schema=None, parent_key=[], sep='__', level=0, max
     items = []
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
-        if isinstance(v, collections.MutableMapping) and level < max_level:
+        if isinstance(v, collections.abc.MutableMapping) and level < max_level:
             items.extend(flatten_record(v, flatten_schema, parent_key + [k], sep=sep, level=level + 1, max_level=max_level).items())
         else:
             items.append((new_key, json.dumps(v) if _should_json_dump_value(k, v, flatten_schema) else v))


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

This PR is necessary because in Python 3.10 and above, `MutableMapping` cannot be imported from the `collections` package - it must be imported from `collections.abc`. Per the [documentation](https://docs.python.org/3.9/library/collections.html):

> Deprecated since version 3.3, will be removed in version 3.10: Moved [Collections Abstract Base Classes](https://docs.python.org/3.9/library/collections.abc.html#collections-abstract-base-classes) to the [collections.abc](https://docs.python.org/3.9/library/collections.abc.html#module-collections.abc) module. For backwards compatibility, they continue to be visible in this module through Python 3.9.

The `collections.abc` import is supported in earlier versions of Python as well. I've personally tested this change down to Python 3.7.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 

^ I can't view that Baseline Security Requirements document, but I don't believe this PR has any negative impact on security.