### PR TITLE
Support aws iam role metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Full list of options in `config.json`:
 | password                            | String  | Yes        | Redshift Password                                             |
 | dbname                              | String  | Yes        | Redshift Database name                                        |
 | aws_profile                         | String  | No         | AWS profile name for profile based authentication. If not provided, `AWS_PROFILE` environment variable will be used. |
-| aws_access_key_id                   | String  | No         | S3 Access Key Id. Used for S3 and Redshfit copy operations. If not provided, `AWS_ACCESS_KEY_ID` environment variable will be used. |
-| aws_secret_access_key               | String  | No         | S3 Secret Access Key. Used for S3 and Redshfit copy operations. If not provided, `AWS_SECRET_ACCESS_KEY` environment variable will be used.  |
+| aws_access_key_id                   | String  | No         | S3 Access Key Id. Used for S3 and Redshfit copy operations. If not provided, `AWS_ACCESS_KEY_ID` environment variable will be used. Lastly, if env is not found, will assume AWS service role and use temporary credentials instead |
+| aws_secret_access_key               | String  | No         | S3 Secret Access Key. Used for S3 and Redshfit copy operations. If not provided, `AWS_SECRET_ACCESS_KEY` environment variable will be used. Lastly, if env is not found, will assume AWS service role and use temporary credentials instead |
 | aws_session_token                   | String  | No         | S3 AWS STS token for temporary credentials. If not provided, `AWS_SESSION_TOKEN` environment variable will be used. |
 | aws_redshift_copy_role_arn          | String  | No         | AWS Role ARN to be used for the Redshift COPY operation. Used instead of the given AWS keys for the COPY operation if provided - the keys are still used for other S3 operations |
 | s3_acl                              | String  | No         | S3 Object ACL                                                |

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -246,8 +246,8 @@ class DbSync:
         elif aws_profile:
             aws_session = boto3.session.Session(profile_name=aws_profile)
         else:
-            # Attempt to retrieve the temporary credentials from AWS service role
-            # TODO: Add logging and more explain
+            # Attempt to retrieve the temporary credentials from AWS IAM Service role
+            self.logger.info("No AWS credentials or profile found. Will attempt to assume service role and retrieve temporary credentials")
             aws_session = boto3.session.Session()
             
         credentials = aws_session.get_credentials().get_frozen_credentials()

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -243,14 +243,19 @@ class DbSync:
                 aws_secret_access_key=aws_secret_access_key,
                 aws_session_token=aws_session_token
             )
-            credentials = aws_session.get_credentials().get_frozen_credentials()
-
-            # Explicitly set credentials to those fetched from Boto so we can re-use them in COPY SQL if necessary
-            self.connection_config['aws_access_key_id'] = credentials.access_key
-            self.connection_config['aws_secret_access_key'] = credentials.secret_key
-            self.connection_config['aws_session_token'] = credentials.token
-        else:
+        elif aws_profile:
             aws_session = boto3.session.Session(profile_name=aws_profile)
+        else:
+            # Attempt to retrieve the temporary credentials from AWS service role
+            # TODO: Add logging and more explain
+            aws_session = boto3.session.Session()
+            
+        credentials = aws_session.get_credentials().get_frozen_credentials()
+
+        # Explicitly set credentials to those fetched from Boto so we can re-use them in COPY SQL if necessary
+        self.connection_config['aws_access_key_id'] = credentials.access_key
+        self.connection_config['aws_secret_access_key'] = credentials.secret_key
+        self.connection_config['aws_session_token'] = credentials.token
 
         self.s3 = aws_session.client('s3')
         self.skip_updates = self.connection_config.get('skip_updates', False)


### PR DESCRIPTION
## Context

When run on AWS services such as EC2 and Lambda, one does not require to provide AWS credentials as those can be assumed via the service metadata and role attached to the relevant service i.e. EC2.

This PR adds the boto3 session that will attempt to assume role, if no AWS credentials are found via environmental variables.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 

I do not have access to the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) document 🤷 
