### PR TITLE
Fix MutableMapping for python 3.10

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -1,9 +1,16 @@
-import collections
+
+import sys
+# pylint: disable=no-name-in-module
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
+# pylint: enable=no-name-in-module
+
 import itertools
 import json
 import os
 import re
-import sys
 import time
 
 import boto3
@@ -161,7 +168,7 @@ def flatten_record(d, flatten_schema=None, parent_key=[], sep='__', level=0, max
     items = []
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
-        if isinstance(v, collections.MutableMapping) and level < max_level:
+        if isinstance(v, MutableMapping) and level < max_level:
             items.extend(flatten_record(v, flatten_schema, parent_key + [k], sep=sep, level=level + 1, max_level=max_level).items())
         else:
             items.append((new_key, json.dumps(v) if _should_json_dump_value(k, v, flatten_schema) else v))


### PR DESCRIPTION
## Context

Support Python >= 3.10

This fails on Python 3.10:

```
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -   File "/virtualenvs/pipelinewise-target-redshift/bin/target-redshift", line 8, in <module>
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -     sys.exit(main())
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -   File "/virtualenvs/pipelinewise-target-redshift/lib/python3.10/site-packages/target_redshift/__init__.py", line 447, in main
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -     persist_lines(config, singer_messages, table_cache)
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -   File "/virtualenvs/pipelinewise-target-redshift/lib/python3.10/site-packages/target_redshift/__init__.py", line 162, in persist_lines
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -     primary_key_string = stream_to_sync[stream].record_primary_key_string(o['record'])
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -   File "/virtualenvs/pipelinewise-target-redshift/lib/python3.10/site-packages/target_redshift/db_sync.py", line 360, in record_primary_key_string
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -     flatten = flatten_record(record, self.flatten_schema, max_level=self.data_flattening_max_level)
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -   File "/virtualenvs/pipelinewise-target-redshift/lib/python3.10/site-packages/target_redshift/db_sync.py", line 164, in flatten_record
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO -     if isinstance(v, collections.MutableMapping) and level < max_level:
[2022-05-25, 16:19:55 BST] {{subprocess.py:92}} INFO - AttributeError: module 'collections' has no attribute 'MutableMapping'
```

See https://stackoverflow.com/a/71902541/2738092 for context.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 

