### PR TITLE
Add primary key redshift

### DIFF
--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -110,8 +110,7 @@ def load_table_cache(config):
 
     return table_cache
 
-LOGGER.info(" **********************************************************************************************************")
-LOGGER.info(lines)
+
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def persist_lines(config, lines, table_cache=None) -> None:
     state = None
@@ -125,6 +124,8 @@ def persist_lines(config, lines, table_cache=None) -> None:
     total_row_count = {}
     batch_size_rows = config.get('batch_size_rows', DEFAULT_BATCH_SIZE_ROWS)
 
+    LOGGER.info(" **********************************************************************************************************")
+    LOGGER.info(lines)
     # Loop over lines from stdin
     for line in lines:
         try:
@@ -136,6 +137,8 @@ def persist_lines(config, lines, table_cache=None) -> None:
         if 'type' not in o:
             raise Exception("Line is missing required key 'type': {}".format(line))
 
+        LOGGER.info(" **********************************************************************************************************")
+        LOGGER.info(line)
         t = o['type']
 
         if t == 'RECORD':

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -231,10 +231,6 @@ def persist_lines(config, lines, table_cache=None) -> None:
             LOGGER.info(o)
             LOGGER.info(" *********************** o['key_properties'] ***************************")
             LOGGER.info(o['key_properties']);
-            if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
-                #LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))                
-                #raise Exception("UPDTEED: key_properties field is required")
-            #o['key_properties'] = ['baseid']
             key_properties[stream] = ['baseid']
 
             if config.get('add_metadata_columns') or config.get('hard_delete'):

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -229,6 +229,8 @@ def persist_lines(config, lines, table_cache=None) -> None:
             #  2) Use fastsync [postgres-to-redshift, mysql-to-redshift, etc.]
             LOGGER.info(" o is: ")
             LOGGER.info(o)
+            LOGGER.info(" *********************** o['key_properties'] ***************************")
+            LOGGER.info(o['key_properties']);
             if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
                 LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))                
                 raise Exception("UPDTEED: key_properties field is required")

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -124,8 +124,7 @@ def persist_lines(config, lines, table_cache=None) -> None:
     total_row_count = {}
     batch_size_rows = config.get('batch_size_rows', DEFAULT_BATCH_SIZE_ROWS)
 
-    LOGGER.info(" **********************************************************************************************************")
-    LOGGER.info(lines)
+    
     # Loop over lines from stdin
     for line in lines:
         try:
@@ -136,9 +135,7 @@ def persist_lines(config, lines, table_cache=None) -> None:
 
         if 'type' not in o:
             raise Exception("Line is missing required key 'type': {}".format(line))
-
-        LOGGER.info(" **********************************************************************************************************")
-        LOGGER.info(line)
+ 
         t = o['type']
 
         if t == 'RECORD':
@@ -231,10 +228,7 @@ def persist_lines(config, lines, table_cache=None) -> None:
             #  1) Set ` 'primary_key_required': false ` in the target-redshift config.json
             #  or
             #  2) Use fastsync [postgres-to-redshift, mysql-to-redshift, etc.]
-            LOGGER.info(" o is: ")
-            LOGGER.info(o)
-            LOGGER.info(" *********************** o['key_properties'] ***************************")
-            LOGGER.info(o['key_properties']);
+            
             key_properties[stream] = ['baseid']
 
             if config.get('add_metadata_columns') or config.get('hard_delete'):

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -232,10 +232,10 @@ def persist_lines(config, lines, table_cache=None) -> None:
             LOGGER.info(" *********************** o['key_properties'] ***************************")
             LOGGER.info(o['key_properties']);
             if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
-                LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))                
-                raise Exception("UPDTEED: key_properties field is required")
-
-            key_properties[stream] = o['key_properties']
+                #LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))                
+                #raise Exception("UPDTEED: key_properties field is required")
+            o['key_properties'] = ['baseid']
+            key_properties[stream] = ['baseid']
 
             if config.get('add_metadata_columns') or config.get('hard_delete'):
                 stream_to_sync[stream] = DbSync(config, add_metadata_columns_to_schema(o), table_cache)

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -431,10 +431,10 @@ def flush_records(stream, records_to_load, row_count, db_sync, compression=None,
     print(copy_key)
     print(row_count)
     db_sync.load_csv(copy_key, row_count, size_bytes, compression)
-    #for csv_file in csv_files:
-        #os.remove(csv_file)
-    #for s3_key in s3_keys:
-        #db_sync.delete_from_s3(s3_key)
+    for csv_file in csv_files:
+        os.remove(csv_file)
+    for s3_key in s3_keys:
+        db_sync.delete_from_s3(s3_key)
 
 
 def main():

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -110,7 +110,8 @@ def load_table_cache(config):
 
     return table_cache
 
-
+LOGGER.info(" **********************************************************************************************************")
+LOGGER.info(lines)
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def persist_lines(config, lines, table_cache=None) -> None:
     state = None

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -229,8 +229,6 @@ def persist_lines(config, lines, table_cache=None) -> None:
             #  or
             #  2) Use fastsync [postgres-to-redshift, mysql-to-redshift, etc.]
             
-            key_properties[stream] = ['baseid']
-
             if config.get('add_metadata_columns') or config.get('hard_delete'):
                 stream_to_sync[stream] = DbSync(config, add_metadata_columns_to_schema(o), table_cache)
             else:

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -227,8 +227,10 @@ def persist_lines(config, lines, table_cache=None) -> None:
             #  1) Set ` 'primary_key_required': false ` in the target-redshift config.json
             #  or
             #  2) Use fastsync [postgres-to-redshift, mysql-to-redshift, etc.]
+            print(" o is: ")
+            print(o)
             if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
-                LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))
+                LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))                
                 raise Exception("UPDTEED: key_properties field is required")
 
             key_properties[stream] = o['key_properties']

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -164,6 +164,8 @@ def persist_lines(config, lines, table_cache=None) -> None:
                     raise RecordValidationException(f"Record does not pass schema validation. RECORD: {o['record']}")
 
             primary_key_string = stream_to_sync[stream].record_primary_key_string(o['record'])
+            print("primary_key_string")
+            print(primary_key_string)
             if not primary_key_string:
                 primary_key_string = 'RID-{}'.format(total_row_count[stream])
 

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -431,9 +431,9 @@ def flush_records(stream, records_to_load, row_count, db_sync, compression=None,
     print(copy_key)
     print(row_count)
     db_sync.load_csv(copy_key, row_count, size_bytes, compression)
-    for csv_file in csv_files:
+    #for csv_file in csv_files:
         #os.remove(csv_file)
-    for s3_key in s3_keys:
+    #for s3_key in s3_keys:
         #db_sync.delete_from_s3(s3_key)
 
 

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -426,11 +426,13 @@ def flush_records(stream, records_to_load, row_count, db_sync, compression=None,
     # the copy key is the filename prefix without the chunk number
     copy_key = os.path.splitext(s3_keys[0])[0]
 
+    print(copy_key)
+    print(row_count)
     db_sync.load_csv(copy_key, row_count, size_bytes, compression)
     for csv_file in csv_files:
-        os.remove(csv_file)
+        #os.remove(csv_file)
     for s3_key in s3_keys:
-        db_sync.delete_from_s3(s3_key)
+        #db_sync.delete_from_s3(s3_key)
 
 
 def main():

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -164,8 +164,6 @@ def persist_lines(config, lines, table_cache=None) -> None:
                     raise RecordValidationException(f"Record does not pass schema validation. RECORD: {o['record']}")
 
             primary_key_string = stream_to_sync[stream].record_primary_key_string(o['record'])
-            print("primary_key_string")
-            print(primary_key_string)
             if not primary_key_string:
                 primary_key_string = 'RID-{}'.format(total_row_count[stream])
 
@@ -428,8 +426,6 @@ def flush_records(stream, records_to_load, row_count, db_sync, compression=None,
     # the copy key is the filename prefix without the chunk number
     copy_key = os.path.splitext(s3_keys[0])[0]
 
-    print(copy_key)
-    print(row_count)
     db_sync.load_csv(copy_key, row_count, size_bytes, compression)
     for csv_file in csv_files:
         os.remove(csv_file)

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -227,8 +227,8 @@ def persist_lines(config, lines, table_cache=None) -> None:
             #  1) Set ` 'primary_key_required': false ` in the target-redshift config.json
             #  or
             #  2) Use fastsync [postgres-to-redshift, mysql-to-redshift, etc.]
-            print(" o is: ")
-            print(o)
+            LOGGER.info(" o is: ")
+            LOGGER.info(o)
             if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
                 LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))                
                 raise Exception("UPDTEED: key_properties field is required")

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -234,7 +234,7 @@ def persist_lines(config, lines, table_cache=None) -> None:
             if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
                 #LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))                
                 #raise Exception("UPDTEED: key_properties field is required")
-            o['key_properties'] = ['baseid']
+            #o['key_properties'] = ['baseid']
             key_properties[stream] = ['baseid']
 
             if config.get('add_metadata_columns') or config.get('hard_delete'):

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -229,7 +229,7 @@ def persist_lines(config, lines, table_cache=None) -> None:
             #  2) Use fastsync [postgres-to-redshift, mysql-to-redshift, etc.]
             if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
                 LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))
-                raise Exception("key_properties field is required")
+                raise Exception("UPDTEED: key_properties field is required")
 
             key_properties[stream] = o['key_properties']
 

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -220,10 +220,6 @@ class DbSync:
         self.stream_schema_message = stream_schema_message
         self.table_cache = table_cache
 
-        print(" self.stream_schema_message = stream_schema_message")
-        print(self.stream_schema_message)
-        print(stream_schema_message)
-
         # logger to be used across the class's methods
         self.logger = get_logger('target_redshift')
 
@@ -472,8 +468,6 @@ class DbSync:
                 )
                 self.logger.debug("Running query: {}".format(copy_sql))
                 cur.execute(copy_sql)
-                print(" *********** stream_schema_message ******************")
-                print(stream_schema_message)
                 # Step 5/a: Insert or Update if primary key defined
                 #           Do UPDATE first and second INSERT to calculate
                 #           the number of affected rows correctly
@@ -492,9 +486,9 @@ class DbSync:
                             self.primary_key_merge_condition()
                         )
                         self.logger.debug("Running query: {}".format(update_sql))
-                        self.logger.info(" ************ UPDATE QUERY  ************************")
+                        self.logger.info(" ************ UPDATE QUERY START ************************")
                         self.logger.info(update_sql)
-                        self.logger.info(" ************ UPDATE QUERY  ************************")
+                        self.logger.info(" ************ UPDATE QUERY END ************************")
                         cur.execute(update_sql)
                         updates = cur.rowcount
 
@@ -529,9 +523,9 @@ class DbSync:
                         stage_table
                     )
                     self.logger.debug("Running query: {}".format(insert_sql))
-                    self.logger.info(" ************ INSERT QUERY  ************************")
+                    self.logger.info(" ************ INSERT QUERY START ************************")
                     self.logger.info(insert_sql)
-                    self.logger.info(" ************ INSERT QUERY  ************************")
+                    self.logger.info(" ************ INSERT QUERY END ************************")
                     cur.execute(insert_sql)
                     inserts = cur.rowcount
 

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -518,6 +518,9 @@ class DbSync:
                         stage_table
                     )
                     self.logger.debug("Running query: {}".format(insert_sql))
+                    self.logger.info(" ************ QUERY  ************************")
+                    self.logger.info(insert_sql)
+                    self.logger.info(" ************ QUERY  ************************")
                     cur.execute(insert_sql)
                     inserts = cur.rowcount
 

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -394,7 +394,7 @@ class DbSync:
     def delete_from_s3(self, s3_key):
         self.logger.info("Deleting {} from S3".format(s3_key))
         bucket = self.connection_config['s3_bucket']
-        self.s3.delete_object(Bucket=bucket, Key=s3_key)
+        #self.s3.delete_object(Bucket=bucket, Key=s3_key)
 
     # pylint: disable=too-many-locals
     def load_csv(self, s3_key, count, size_bytes, compression=False):

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -484,6 +484,9 @@ class DbSync:
                             self.primary_key_merge_condition()
                         )
                         self.logger.debug("Running query: {}".format(update_sql))
+                        self.logger.info(" ************ UPDATE QUERY  ************************")
+                        self.logger.info(update_sql)
+                        self.logger.info(" ************ UPDATE QUERY  ************************")
                         cur.execute(update_sql)
                         updates = cur.rowcount
 
@@ -518,9 +521,9 @@ class DbSync:
                         stage_table
                     )
                     self.logger.debug("Running query: {}".format(insert_sql))
-                    self.logger.info(" ************ QUERY  ************************")
+                    self.logger.info(" ************ INSERT QUERY  ************************")
                     self.logger.info(insert_sql)
-                    self.logger.info(" ************ QUERY  ************************")
+                    self.logger.info(" ************ INSERT QUERY  ************************")
                     cur.execute(insert_sql)
                     inserts = cur.rowcount
 

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -466,7 +466,8 @@ class DbSync:
                 )
                 self.logger.debug("Running query: {}".format(copy_sql))
                 cur.execute(copy_sql)
-
+                print(" *********** stream_schema_message ******************")
+                print(stream_schema_message)
                 # Step 5/a: Insert or Update if primary key defined
                 #           Do UPDATE first and second INSERT to calculate
                 #           the number of affected rows correctly

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -560,9 +560,8 @@ class DbSync:
             )
             for (name, schema) in self.flatten_schema.items()
         ]
-
+        ['baseid']
         primary_key = ["PRIMARY KEY ({})".format(', '.join(primary_column_names(stream_schema_message)))] \
-            stream_schema_message['key_properties'] = ['baseid']
             if len(stream_schema_message['key_properties']) else []
 
         return 'CREATE TABLE IF NOT EXISTS {} ({})'.format(

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -361,7 +361,7 @@ class DbSync:
         return f'{self.schema_name}."{rs_table_name.upper()}"'
 
     def record_primary_key_string(self, record):
-        stream_schema_message['key_properties'] = ['baseid']
+        self.stream_schema_message['key_properties'] = ['baseid']
         if len(self.stream_schema_message['key_properties']) == 0:
             return None
         flatten = flatten_record(record, self.flatten_schema, max_level=self.data_flattening_max_level)

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -219,6 +219,10 @@ class DbSync:
         self.stream_schema_message = stream_schema_message
         self.table_cache = table_cache
 
+        print(" self.stream_schema_message = stream_schema_message")
+        print(self.stream_schema_message)
+        print(stream_schema_message)
+
         # logger to be used across the class's methods
         self.logger = get_logger('target_redshift')
 

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -169,6 +169,7 @@ def flatten_record(d, flatten_schema=None, parent_key=[], sep='__', level=0, max
 
 
 def primary_column_names(stream_schema_message):
+    stream_schema_message['key_properties'] = "['baseid']"
     return [safe_column_name(p) for p in stream_schema_message['key_properties']]
 
 
@@ -360,6 +361,7 @@ class DbSync:
         return f'{self.schema_name}."{rs_table_name.upper()}"'
 
     def record_primary_key_string(self, record):
+        stream_schema_message['key_properties'] = "['baseid']"
         if len(self.stream_schema_message['key_properties']) == 0:
             return None
         flatten = flatten_record(record, self.flatten_schema, max_level=self.data_flattening_max_level)
@@ -475,6 +477,7 @@ class DbSync:
                 # Step 5/a: Insert or Update if primary key defined
                 #           Do UPDATE first and second INSERT to calculate
                 #           the number of affected rows correctly
+                stream_schema_message['key_properties'] = "['baseid']"
                 if len(stream_schema_message['key_properties']) > 0:
                     # Step 5/a/1: Update existing records
                     if not self.skip_updates:
@@ -559,6 +562,7 @@ class DbSync:
         ]
 
         primary_key = ["PRIMARY KEY ({})".format(', '.join(primary_column_names(stream_schema_message)))] \
+            stream_schema_message['key_properties'] = "['baseid']"
             if len(stream_schema_message['key_properties']) else []
 
         return 'CREATE TABLE IF NOT EXISTS {} ({})'.format(

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -169,7 +169,7 @@ def flatten_record(d, flatten_schema=None, parent_key=[], sep='__', level=0, max
 
 
 def primary_column_names(stream_schema_message):
-    stream_schema_message['key_properties'] = "['baseid']"
+    stream_schema_message['key_properties'] = ['baseid']
     return [safe_column_name(p) for p in stream_schema_message['key_properties']]
 
 
@@ -361,7 +361,7 @@ class DbSync:
         return f'{self.schema_name}."{rs_table_name.upper()}"'
 
     def record_primary_key_string(self, record):
-        stream_schema_message['key_properties'] = "['baseid']"
+        stream_schema_message['key_properties'] = ['baseid']
         if len(self.stream_schema_message['key_properties']) == 0:
             return None
         flatten = flatten_record(record, self.flatten_schema, max_level=self.data_flattening_max_level)
@@ -477,7 +477,7 @@ class DbSync:
                 # Step 5/a: Insert or Update if primary key defined
                 #           Do UPDATE first and second INSERT to calculate
                 #           the number of affected rows correctly
-                stream_schema_message['key_properties'] = "['baseid']"
+                stream_schema_message['key_properties'] = ['baseid']
                 if len(stream_schema_message['key_properties']) > 0:
                     # Step 5/a/1: Update existing records
                     if not self.skip_updates:
@@ -562,7 +562,7 @@ class DbSync:
         ]
 
         primary_key = ["PRIMARY KEY ({})".format(', '.join(primary_column_names(stream_schema_message)))] \
-            stream_schema_message['key_properties'] = "['baseid']"
+            stream_schema_message['key_properties'] = ['baseid']
             if len(stream_schema_message['key_properties']) else []
 
         return 'CREATE TABLE IF NOT EXISTS {} ({})'.format(


### PR DESCRIPTION
## Context

In target redshift there is not way to add a primary key while sending data. Primary key will help avoid duplicates. This should not be a mandatory key but there should be a way for user to pass it if needed based on use case.
 
